### PR TITLE
gradle: update to 6.0.1 and improve configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,6 +59,6 @@ tasks.withType<ShadowJar> {
     mergeServiceFiles()
 }
 
-tasks.create("stage") {
+tasks.register<DefaultTask>("stage") {
     dependsOn("shadowJar")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,4 @@
+# See https://dev.to/jmfayard/configuring-gradle-with-gradle-properties-211k
+org.gradle.caching=true
+org.gradle.parallel=true
+kotlin.code.style=official

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- update to Gradle 6
- add Gradle properties that makes the build faster
- use the lazy Gradle API for tasks creation