### PR TITLE
gradle: replace compile vs implementation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,15 +16,15 @@ repositories {
 }
 
 dependencies {
-    compile(kotlin("stdlib"))
+    implementation(kotlin("stdlib"))
 
-    compile("io.micronaut:micronaut-runtime:1.2.7")
-    compile("io.micronaut:micronaut-http-server-netty:1.2.7")
-    compile("io.micronaut:micronaut-views:1.2.0")
-    compile("ch.qos.logback:logback-classic:1.2.3")
+    implementation("io.micronaut:micronaut-runtime:1.2.7")
+    implementation("io.micronaut:micronaut-http-server-netty:1.2.7")
+    implementation("io.micronaut:micronaut-views:1.2.0")
+    implementation("ch.qos.logback:logback-classic:1.2.3")
 
-    runtime("com.fasterxml.jackson.module:jackson-module-kotlin:2.9.7")
-    runtime("org.thymeleaf:thymeleaf:3.0.11.RELEASE")
+    runtimeOnly("com.fasterxml.jackson.module:jackson-module-kotlin:2.9.7")
+    runtimeOnly("org.thymeleaf:thymeleaf:3.0.11.RELEASE")
 
     kapt("io.micronaut:micronaut-inject-java:1.2.7")
 }


### PR DESCRIPTION
That should have been in my previous pull-request but I didn't notice it. 

In Gradle, the `compile` configuration is deprecated
`implementation` or `api` should be used instead
For background infos, see https://docs.gradle.org/current/userguide/java_library_plugin.html